### PR TITLE
Use hostname instead of IP in local-nama entrypoint

### DIFF
--- a/app/data/config/local-namada/start-node.sh
+++ b/app/data/config/local-namada/start-node.sh
@@ -10,7 +10,7 @@ cleanup() {
 }
 
 
-export PUBLIC_IP=$(ip a | grep -oE 'inet ([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2} brd ([0-9]{1,3}\.){3}[0-9]{1,3}' | grep -v '127.0.0.1' | awk '{print $2}' | cut -d '/' -f1)
+export PUBLIC_IP=$(hostname)
 export ALIAS=$(hostname)
 
 if [ ! -f "/root/.namada-shared/chain.config" ]; then


### PR DESCRIPTION
As the Docker container's IPs are non-deterministic, stopping and resuming the local chain can cause errors due to new IPs being assigned to the same container on each restart.    
This small change leverages Docker's internal DNS to connect validators to each other.    
 
I didn't test this on this repository, instead, I isolated this script and its related files (docker-compose.yml, ...) on my machine and it works perfectly